### PR TITLE
New exception for failed operations

### DIFF
--- a/src/Adapters/Memcached.php
+++ b/src/Adapters/Memcached.php
@@ -18,7 +18,7 @@ use MatthiasMullie\Scrapbook\KeyValueStore;
 class Memcached implements KeyValueStore
 {
     /**
-     * @var Memcached
+     * @var \Memcached
      */
     protected $client;
 
@@ -138,7 +138,7 @@ class Memcached implements KeyValueStore
         if (defined('HHVM_VERSION')) {
             $nums = array_filter(array_keys($items), 'is_numeric');
             if (!empty($nums)) {
-                $this->setMultiNumericItemsForHHVM($nums, $expire);
+                $this->setMultiNumericItemsForHHVM($items, $nums, $expire);
             }
         }
 

--- a/src/Adapters/Memcached.php
+++ b/src/Adapters/Memcached.php
@@ -137,8 +137,8 @@ class Memcached implements KeyValueStore
          */
         if (defined('HHVM_VERSION')) {
             $nums = array_filter(array_keys($items), 'is_numeric');
-            if ($nums) {
-                $this->setMultiNumericForHHVM($nums, $expire);
+            if (!empty($nums)) {
+                $this->setMultiNumericItemsForHHVM($nums, $expire);
             }
         }
 

--- a/src/Exception/OperationFailed.php
+++ b/src/Exception/OperationFailed.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MatthiasMullie\Scrapbook\Exception;
+
+/**
+ * @author Martin Georgiev <martin.georgiev@gmail.com>
+ * @copyright Copyright (c) 2017, Martin Georgiev. All rights reserved
+ * @license LICENSE MIT
+ */
+class OperationFailed extends Exception
+{
+    /**
+     * @var int
+     */
+    private $errorCode;
+
+    /**
+     * @var int
+     */
+    private $errorMessage;
+
+    /**
+     * Set the error (result) code for the (last) Memcached operation
+     *
+     * @param int $errorCode
+     *
+     * @return OperationFailed
+     */
+    public function setResultCode($errorCode)
+    {
+        $this->errorCode = $errorCode;
+
+        return $this;
+    }
+
+    /**
+     * Get the error (result) code for the (last) Memcached operation
+     *
+     * @return int
+     */
+    public function getResultCode()
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * Set the error (result) message for the (last) Memcached operation
+     *
+     * @param string $errorMessage
+     *
+     * @return OperationFailed
+     */
+    public function setResultMessage($errorMessage)
+    {
+        $this->errorMessage = $errorMessage;
+
+        return $this;
+    }
+
+    /**
+     * Get the error (result) message for the (last) Memcached operation
+     *
+     * @return string
+     */
+    public function getResultMessage()
+    {
+        return $this->errorMessage;
+    }
+}

--- a/src/Exception/OperationFailed.php
+++ b/src/Exception/OperationFailed.php
@@ -15,7 +15,7 @@ class OperationFailed extends Exception
     private $errorCode;
 
     /**
-     * @var int
+     * @var string
      */
     private $errorMessage;
 
@@ -26,7 +26,7 @@ class OperationFailed extends Exception
      *
      * @return OperationFailed
      */
-    public function setResultCode($errorCode)
+    public function setErrorCode($errorCode)
     {
         $this->errorCode = $errorCode;
 
@@ -38,7 +38,7 @@ class OperationFailed extends Exception
      *
      * @return int
      */
-    public function getResultCode()
+    public function getErrorCode()
     {
         return $this->errorCode;
     }
@@ -50,7 +50,7 @@ class OperationFailed extends Exception
      *
      * @return OperationFailed
      */
-    public function setResultMessage($errorMessage)
+    public function setErrorMessage($errorMessage)
     {
         $this->errorMessage = $errorMessage;
 
@@ -62,7 +62,7 @@ class OperationFailed extends Exception
      *
      * @return string
      */
-    public function getResultMessage()
+    public function getErrorMessage()
     {
         return $this->errorMessage;
     }


### PR DESCRIPTION
This PR shall provide a graceful way of handling failures by `Memcached::getMulti`.
Previously only the happy path of `Memcached::getMulti` was covered. This makes it harder to debug in PHP before v7 as uncatchable error will be thrown.

Bonus:
Slight improvements for the comment blocks, so NetBeans can parse them as normal phpDoc blocks.