### PR TITLE
Fixed StampedeProtector for phpredis > 4.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "ext-apc": ">=3.1.1",
     "ext-couchbase": ">=2.0.0",
     "ext-memcached": ">=2.0.0",
-    "ext-redis": ">=2.2.0 || 0.0.0.0",
+    "ext-redis": ">=4.0.0 || 0.0.0.0",
     "ext-pdo": ">=0.1.0",
     "league/flysystem": "~1.0"
   },

--- a/src/Adapters/Redis.php
+++ b/src/Adapters/Redis.php
@@ -106,7 +106,7 @@ class Redis implements KeyValueStore
         $tokens = array();
         foreach ($values as $key => $value) {
             // filter out non-existing values
-            if ($exists[$key] === false) {
+            if ($exists[$key] === 0) {
                 unset($values[$key]);
                 continue;
             }

--- a/src/Scale/StampedeProtector.php
+++ b/src/Scale/StampedeProtector.php
@@ -30,10 +30,10 @@ use MatthiasMullie\Scrapbook\KeyValueStore;
  * these processes will poll the cache to see if the value has already been
  * stored in the meantime.
  *
- * The stampede protection will only be temporary, for $sla milliseconds. We
+ * The stampede protection will only be temporary, for $sla seconds. We
  * need to limit it because the first process (tasked with filling the cache
  * after executing the expensive operation) may fail/crash/... If the expensive
- * operation fails to conclude in < $sla milliseconds.
+ * operation fails to conclude in < $sla seconds.
  * This class guarantees that the stampede will hold off for $sla amount of time
  * but after that, all follow-up requests will go through without cached values
  * and cause a stampede after all, if the initial process fails to complete
@@ -51,11 +51,11 @@ class StampedeProtector implements KeyValueStore
     protected $cache = array();
 
     /**
-     * Amount of time, in milliseconds, this class guarantees protection.
+     * Amount of time, in seconds, this class guarantees protection.
      *
      * @var int
      */
-    protected $sla = 1000;
+    protected $sla = 1;
 
     /**
      * Amount of times every process will poll within $sla time.
@@ -66,9 +66,9 @@ class StampedeProtector implements KeyValueStore
 
     /**
      * @param KeyValueStore $cache The real cache we'll buffer for
-     * @param int           $sla   Stampede protection time, in milliseconds
+     * @param int           $sla   Stampede protection time, in seconds
      */
-    public function __construct(KeyValueStore $cache, $sla = 1000)
+    public function __construct(KeyValueStore $cache, $sla = 1)
     {
         $this->cache = $cache;
         $this->sla = $sla;
@@ -87,6 +87,7 @@ class StampedeProtector implements KeyValueStore
 
     /**
      * {@inheritdoc}
+     * @throws InvalidKey
      */
     public function getMulti(array $keys, array &$tokens = null)
     {
@@ -240,6 +241,7 @@ class StampedeProtector implements KeyValueStore
      * @param array $keys
      *
      * @return string[] Array of keys that were successfully protected
+     * @throws InvalidKey
      */
     protected function protect(array $keys)
     {
@@ -269,7 +271,7 @@ class StampedeProtector implements KeyValueStore
      */
     protected function sleep()
     {
-        $break = $this->sla / $this->attempts;
+        $break = $this->sla * 1000 / $this->attempts;
         usleep(1000 * $break);
 
         return true;


### PR DESCRIPTION
This will break for phpredis < 4.0.0 so its not backwards compatibility. 

I tried to run the tests on my local machine but with no luck. 
``` 
Step 6/7 : COPY tests/Docker tests/docker
 ---> Using cache
 ---> 474441258ea4
Step 7/7 : RUN tests/docker/build-php.sh
 ---> Running in 923b6ca5d785
/bin/sh: 1: tests/docker/build-php.sh: not found
ERROR: Service 'php' failed to build : The command '/bin/sh -c tests/docker/build-php.sh' returned a non-zero code: 127
```

