### PR TITLE
Fix lingering stampede causing unnecessary wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 
-## [x.y.z] - a-b-c
-### Changed
-- Refactored tests for PHPUnit 10.x compat
+## [1.5.2] - 2024-01-09
+### Fixed
+- Stampede: removed unnecessary wait caused by lingering stampede key
 
 
 ## [1.5.1] - 2023-01-26

--- a/src/Scale/StampedeProtector.php
+++ b/src/Scale/StampedeProtector.php
@@ -102,6 +102,8 @@ class StampedeProtector implements KeyValueStore
         // we over-fetched (to include stampede indicators), now limit the
         // results to only the keys we requested
         $results = array_intersect_key($values, array_flip($keys));
+        // we may have fetched the values but the stampede protector is still up
+        $protected = array_diff($protected, array_keys($results));
         $tokens = array_intersect_key($tokens, $results);
 
         // we may not have been able to retrieve all keys yet: some may have


### PR DESCRIPTION
When using stampede protection feature If the first request protects a key with key.stampede but also resolve the value faster than the SLA then the next request will read both key and key.stampede and wait one attempt.