### PR TITLE
remove text-transform uppercase for php method headline

### DIFF
--- a/_includes/key-value-store.html
+++ b/_includes/key-value-store.html
@@ -1,4 +1,4 @@
-<h3 class="headline">get($key, &$token = null): mixed|bool</h3>
+<h3 class="headline headline-php-method">get($key, &$token = null): mixed|bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -7,7 +7,7 @@
 <p>Optionally, an 2nd variable can be passed to this function. It will be
 filled with a value that can be used for cas()</p>
 
-<h3 class="headline">getMulti(array $keys, array &$tokens = null): mixed[]</h3>
+<h3 class="headline headline-php-method">getMulti(array $keys, array &$tokens = null): mixed[]</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -24,7 +24,7 @@ array.</p>
 <p>getMulti is preferred over multiple individual get operations as you'll
 get them all in 1 request.</p>
 
-<h3 class="headline">set($key, $value, $expire = 0): bool</h3>
+<h3 class="headline headline-php-method">set($key, $value, $expire = 0): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -34,7 +34,7 @@ which case it will overwrite the existing value for that key)</p>
 <p>Return value is a boolean true when the operation succeeds, or false on
 failure.</p>
 
-<h3 class="headline">setMulti(array $items, $expire = 0): bool[]</h3>
+<h3 class="headline headline-php-method">setMulti(array $items, $expire = 0): bool[]</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -46,7 +46,7 @@ status is a boolean true for success, or false for failure.</p>
 <p>setMulti is preferred over multiple individual set operations as you'll
 set them all in 1 request.</p>
 
-<h3 class="headline">delete($key): bool</h3>
+<h3 class="headline headline-php-method">delete($key): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -56,7 +56,7 @@ Returns true if item existed & was successfully deleted, false otherwise.</p>
 <p>Return value is a boolean true when the operation succeeds, or false on
 failure.</p>
 
-<h3 class="headline">deleteMulti(array $keys): bool[]</h3>
+<h3 class="headline headline-php-method">deleteMulti(array $keys): bool[]</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -66,7 +66,7 @@ individual operations)</p>
 <p>Return value will be an associative array in [key => status] form, where
 status is a boolean true for success, or false for failure.</p>
 
-<h3 class="headline">add($key, $value, $expire = 0): bool</h3>
+<h3 class="headline headline-php-method">add($key, $value, $expire = 0): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -75,7 +75,7 @@ status is a boolean true for success, or false for failure.</p>
 <p>This operation fails (returns false) if the key already exists in cache.
 If the operation succeeds, true will be returned.</p>
 
-<h3 class="headline">replace($key, $value, $expire = 0): bool</h3>
+<h3 class="headline headline-php-method">replace($key, $value, $expire = 0): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -84,7 +84,7 @@ If the operation succeeds, true will be returned.</p>
 <p>This operation fails (returns false) if the key does not yet exist in
 cache. If the operation succeeds, true will be returned.</p>
 
-<h3 class="headline">cas($token, $key, $value, $expire = 0): bool</h3>
+<h3 class="headline headline-php-method">cas($token, $key, $value, $expire = 0): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -95,7 +95,7 @@ it was originally read, when the CAS token was issued.</p>
 what's currently in cache, when a new value has been written to cache
 after we've fetched it. If the operation succeeds, true will be returned.</p>
 
-<h3 class="headline">increment($key, $offset = 1, $initial = 0, $expire = 0): int|bool</h3>
+<h3 class="headline headline-php-method">increment($key, $offset = 1, $initial = 0, $expire = 0): int|bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -106,7 +106,7 @@ exist.</p>
 false for failure (e.g. when the value currently in cache is not a
 number, in which case it can't be incremented)</p>
 
-<h3 class="headline">decrement($key, $offset = 1, $initial = 0, $expire = 0): int|bool</h3>
+<h3 class="headline headline-php-method">decrement($key, $offset = 1, $initial = 0, $expire = 0): int|bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -117,7 +117,7 @@ exist.</p>
 false for failure (e.g. when the value currently in cache is not a
 number, in which case it can't be decremented)</p>
 
-<h3 class="headline">touch($key, $expire): bool</h3>
+<h3 class="headline headline-php-method">touch($key, $expire): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -126,13 +126,13 @@ number, in which case it can't be decremented)</p>
 <p>Return value is a boolean true when the operation succeeds, or false on
 failure.</p>
 
-<h3 class="headline">flush(): bool</h3>
+<h3 class="headline headline-php-method">flush(): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Clears the entire cache.</p>
 
-<h3 class="headline">getCollection(): KeyValueStore</h3>
+<h3 class="headline headline-php-method">getCollection(): KeyValueStore</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 

--- a/_includes/psr-16-cache.html
+++ b/_includes/psr-16-cache.html
@@ -1,46 +1,46 @@
-<h3 class="headline">get($key): mixed</h3>
+<h3 class="headline headline-php-method">get($key): mixed</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Fetch a value from the cache.</p>
 
-<h3 class="headline">set($key, $value, $ttl): bool</h3>
+<h3 class="headline headline-php-method">set($key, $value, $ttl): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Persist data in the cache, uniquely referenced by a key with an optional expiration TTL time.</p>
 
-<h3 class="headline">delete(): void</h3>
+<h3 class="headline headline-php-method">delete(): void</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Delete an item from the cache by its unique key.</p>
 
-<h3 class="headline">clear(): void</h3>
+<h3 class="headline headline-php-method">clear(): void</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Wipe clean the entire cache's keys.</p>
 
-<h3 class="headline">getMultiple($keys): mixed[]</h3>
+<h3 class="headline headline-php-method">getMultiple($keys): mixed[]</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Obtain multiple cache items by their unique keys.</p>
 
-<h3 class="headline">setMultiple($items, $ttl): bool</h3>
+<h3 class="headline headline-php-method">setMultiple($items, $ttl): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Persisting a set of key => value pairs in the cache, with an optional TTL.</p>
 
-<h3 class="headline">deleteMultiple($keys): bool</h3>
+<h3 class="headline headline-php-method">deleteMultiple($keys): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Delete multiple cache items in a single operation.</p>
 
-<h3 class="headline">has($key): bool</h3>
+<h3 class="headline headline-php-method">has($key): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 

--- a/_includes/psr-6-item.html
+++ b/_includes/psr-6-item.html
@@ -1,34 +1,34 @@
-<h3 class="headline">getKey(): string</h3>
+<h3 class="headline headline-php-method">getKey(): string</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Returns the key for the current cache item.</p>
 
-<h3 class="headline">get(): mixed</h3>
+<h3 class="headline headline-php-method">get(): mixed</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Retrieves the value of the item from the cache associated with this object's key.</p>
 
-<h3 class="headline">isHit(): bool</h3>
+<h3 class="headline headline-php-method">isHit(): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Confirms if the cache item lookup resulted in a cache hit.</p>
 
-<h3 class="headline">set($value): static</h3>
+<h3 class="headline headline-php-method">set($value): static</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Sets the value represented by this cache item.</p>
 
-<h3 class="headline">expiresAt($expiration): static</h3>
+<h3 class="headline headline-php-method">expiresAt($expiration): static</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Sets the expiration time for this cache item.</p>
 
-<h3 class="headline">expiresAfter($expiration): static</h3>
+<h3 class="headline headline-php-method">expiresAfter($expiration): static</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 

--- a/_includes/psr-6-pool.html
+++ b/_includes/psr-6-pool.html
@@ -1,52 +1,52 @@
-<h3 class="headline">getItem($key): Item</h3>
+<h3 class="headline headline-php-method">getItem($key): Item</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Returns a Cache Item representing the specified key.</p>
 
-<h3 class="headline">getItems(array $keys = array()): Item[]</h3>
+<h3 class="headline headline-php-method">getItems(array $keys = array()): Item[]</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Returns a traversable set of cache items.</p>
 
-<h3 class="headline">hasItem($key): bool</h3>
+<h3 class="headline headline-php-method">hasItem($key): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Confirms if the cache contains specified cache item.</p>
 
-<h3 class="headline">clear(): bool</h3>
+<h3 class="headline headline-php-method">clear(): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Deletes all items in the pool.</p>
 
-<h3 class="headline">deleteItem($key): bool</h3>
+<h3 class="headline headline-php-method">deleteItem($key): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Removes the item from the pool.</p>
 
-<h3 class="headline">deleteItems(array $keys): bool</h3>
+<h3 class="headline headline-php-method">deleteItems(array $keys): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Removes multiple items from the pool.</p>
 
-<h3 class="headline">save(CacheItemInterface $item): bool</h3>
+<h3 class="headline headline-php-method">save(CacheItemInterface $item): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Persists a cache item immediately.</p>
 
-<h3 class="headline">saveDeferred(CacheItemInterface $item): bool</h3>
+<h3 class="headline headline-php-method">saveDeferred(CacheItemInterface $item): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
 <p>Sets a cache item to be persisted later.</p>
 
-<h3 class="headline">commit(): bool</h3>
+<h3 class="headline headline-php-method">commit(): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 

--- a/extras/transactional-cache.md
+++ b/extras/transactional-cache.md
@@ -56,7 +56,7 @@ from cache instead of the one your intended to commit.
 
 It too is a KeyValueStore, but adds 3 methods:
 
-<h3 class="headline">begin()</h3>
+<h3 class="headline headline-php-method">begin()</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -70,7 +70,7 @@ cache once the original transaction is committed.
 Rolling back a nested transaction will only roll back those changes and leave
 changes in the parent transaction alone.
 
-<h3 class="headline">commit(): bool</h3>
+<h3 class="headline headline-php-method">commit(): bool</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 
@@ -78,7 +78,7 @@ Commits the deferred updates to real cache.
 If the any write fails, all subsequent writes will be aborted & all keys
 that had already been written to will be restored to their original value.
 
-<h3 class="headline">rollback()</h3>
+<h3 class="headline headline-php-method">rollback()</h3>
 <span class="brd-headling"></span>
 <div class="clearfix"></div>
 

--- a/public/assets/css/scrapbook.css
+++ b/public/assets/css/scrapbook.css
@@ -273,3 +273,7 @@ html, body, .jPanelMenu-panel {
 	list-style: outside none none;
 	margin: 0;
 }
+
+.headline-php-method {
+	text-transform: none;
+}


### PR DESCRIPTION
Hello @matthiasmullie

I've started using your package and I noticed at the docs some odd display for PHP methods:

<img width="603" alt="image" src="https://github.com/user-attachments/assets/9d27136b-9188-469c-9904-40668af0d604" />

I feel these headlines hard to read, so I removed text-transform and this is how it looks like:

<img width="594" alt="image" src="https://github.com/user-attachments/assets/765d0e6e-1393-4819-b896-e076bfe118dc" />

Hope it helps, many thanks for this package.
